### PR TITLE
Add modular installation framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+install.log
+status/
+tmp/

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+LOG_FILE="install.log"
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+# Load common functions
+source ./libs/common.sh
+
+mkdir -p status
+
+for module in $(find modules -maxdepth 1 -type f -name '[0-9][0-9]_*.sh' | sort); do
+    log "Executing $(basename "$module")"
+    bash "$module"
+done

--- a/libs/common.sh
+++ b/libs/common.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+log() {
+    echo "$(date '+%Y-%m-%d %H:%M:%S') - $*"
+}

--- a/modules/01_sample.sh
+++ b/modules/01_sample.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -e
+
+# Load common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../libs/common.sh"
+
+MODULE_NAME=$(basename "$0")
+MODULE_ID="${MODULE_NAME%.sh}"
+STATUS_FILE="status/${MODULE_ID}.done"
+
+if [ -f "$STATUS_FILE" ]; then
+    log "$MODULE_ID already completed, skipping"
+    exit 0
+fi
+
+log "Running $MODULE_ID"
+# Example module logic: create marker file under temp directory
+mkdir -p tmp
+# Add a message to show execution
+printf '%s\n' "$MODULE_ID executed" >> tmp/executed.txt
+
+mkdir -p status
+touch "$STATUS_FILE"
+log "$MODULE_ID completed"


### PR DESCRIPTION
## Summary
- add install.sh to run numbered modules and log to install.log
- introduce libs/common.sh with reusable log helper
- create example module 01_sample.sh demonstrating idempotent execution via status markers

## Testing
- `./install.sh`
- `./install.sh`

------
https://chatgpt.com/codex/tasks/task_e_68c52e4adca0832fa7bc11316cd02fb3